### PR TITLE
Add simple end-to-end tests for bzlmod.

### DIFF
--- a/addlicense.sh
+++ b/addlicense.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+if ! command -v addlicense @>&1 >/dev/null; then
+    echo "ERROR: addlicense not installed."
+    echo "Install using https://github.com/google/addlicense#install"
+    exit 1
+fi
+
+addlicense -v -l apache -c 'The Bazel Authors. All rights reserved.' "$@"

--- a/e2e/bzlmod/BUILD.bazel
+++ b/e2e/bzlmod/BUILD.bazel
@@ -1,0 +1,5 @@
+# Basic tests to verify things work under bzlmod
+
+load(":tests.bzl", "bzlmod_test_suite")
+
+bzlmod_test_suite(name = "bzlmod_tests")

--- a/e2e/bzlmod/MODULE.bazel
+++ b/e2e/bzlmod/MODULE.bazel
@@ -1,0 +1,11 @@
+module(
+    name = "e2e_bzlmod",
+    version = "0.0.0",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_testing", version = "0.0.0")
+local_path_override(
+    module_name = "rules_testing",
+    path = "../..",
+)

--- a/e2e/bzlmod/WORKSPACE
+++ b/e2e/bzlmod/WORKSPACE
@@ -1,0 +1,1 @@
+# Empty marker

--- a/e2e/bzlmod/rule_under_test.bzl
+++ b/e2e/bzlmod/rule_under_test.bzl
@@ -1,0 +1,14 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/e2e/bzlmod/tests.bzl
+++ b/e2e/bzlmod/tests.bzl
@@ -1,0 +1,41 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for basic bzlmod functionality."""
+
+load("@rules_testing//lib:analysis_test.bzl", "analysis_test", "test_suite")
+load("@rules_testing//lib:util.bzl", "util")
+
+def _simple_test(name):
+    util.helper_target(
+        native.filegroup,
+        name = name + "_subject",
+        srcs = ["src.txt"],
+        data = ["data.txt"],
+    )
+    analysis_test(
+        name = name,
+        impl = _simple_test_impl,
+        target = name + "_subject",
+    )
+
+def _simple_test_impl(env, target):
+    subject = env.expect.that_target(target)
+    subject.default_outputs().contains_exactly(["src.txt"])
+    subject.runfiles().contains_exactly(["{workspace}/data.txt"])
+
+def bzlmod_test_suite(name):
+    test_suite(name = name, tests = [
+        _simple_test,
+    ])


### PR DESCRIPTION
This is so that the BCR release step has some basic tests to check functionality before being available in BCR.

* Also adds a script to add missing license headers