### PR TITLE
tests: Remove google-internal path from target_subject_test

### DIFF
--- a/tests/truth_tests.bzl
+++ b/tests/truth_tests.bzl
@@ -1199,7 +1199,7 @@ def _target_subject_test(env, target):
     subject = truth.expect(fake_env).that_target(target)
 
     # First a static string, no formatting parameters
-    result = subject.action_generating("third_party/bazel_rules/rules_testing/tests/default_runfile1.txt")
+    result = subject.action_generating("{package}/default_runfile1.txt")
     ut_asserts.true(env, result != None, msg = "action_generating gave None")
 
     # Now try it with formatting parameters


### PR DESCRIPTION
This makes //tests:target_subject_test pass under Bazel on GitHub. The google-internal
path was just an oversight when initially exporting.

Work towards #11