### PR TITLE
style: fix buildifier warnings

### DIFF
--- a/lib/truth.bzl
+++ b/lib/truth.bzl
@@ -143,8 +143,9 @@ def _expect_new(env, meta):
         A struct representing an `Expect` object.
     """
 
-    # buildifier: disable=uninitialized
     meta = meta or _expect_meta_new(env)
+
+    # buildifier: disable=uninitialized
     public = struct(
         # keep sorted start
         meta = meta,

--- a/lib/util.bzl
+++ b/lib/util.bzl
@@ -222,6 +222,7 @@ def skip_test(name):
     )
 
 def _skip_test_impl(ctx):
+    _ = ctx  # @unused
     fail("Should have been skipped")
 
 _skip_test = rule(

--- a/tests/truth_tests.bzl
+++ b/tests/truth_tests.bzl
@@ -17,22 +17,8 @@
 load("@bazel_skylib//lib:unittest.bzl", ut_asserts = "asserts")
 load("//lib:truth.bzl", "matching", "subjects", "truth")
 load("//lib:analysis_test.bzl", "analysis_test", "test_suite")
-load("//lib:util.bzl", "util")
 
 _suite = []
-
-_TEST_FILES_ATTR = {
-    "test_files": attr.label(
-        default = ":truth_tests_data_files",
-        allow_files = True,
-    ),
-}
-_HELPER_ATTR = {
-    "_helper": attr.label(
-        default = ":truth_tests_helper",
-        aspects = [util.testing_aspect],
-    ),
-}
 
 def _fake_env(env):
     failures = []
@@ -1304,20 +1290,6 @@ def _assert_failure(fake_env, expected_strs, *, env, msg = ""):
                 ),
             )
     fake_env.reset()
-
-def _fake_action(outputs = depset()):
-    return struct(
-        mnemonic = "FakeAction",
-        outputs = outputs,
-        argv = None,
-    )
-
-def _fake_ctx(attrs = struct()):
-    return struct(
-        label = Label("//fake/tests:fake_test"),
-        workspace_name = "fake_workspace",
-        attr = attrs,
-    )
 
 def _test_helper_impl(ctx):
     action_output = ctx.actions.declare_file("action.txt")


### PR DESCRIPTION
* Move a uninitialized suppression to the proper place
* Mark an unused var as unused
* Remove some unused private variables

Work towards #11