### PR TITLE
fix: Record match for matching in-order elements

### DIFF
--- a/lib/private/compare_util.bzl
+++ b/lib/private/compare_util.bzl
@@ -138,7 +138,13 @@ def compare_contains_exactly_predicates(*, expect_contains, actual_container):
         expected_entry = expected_queue[pos]
 
         if expected_entry[1].match(actual_entry[1]):
-            continue  # Happy path: both are equal and order is maintained.
+            # Happy path: both are equal and order is maintained.
+            matches[expected_entry[0]] = MatchResult.new(
+                found_at = actual_entry[0],
+                matched_value = actual_entry[1],
+                matcher = expected_entry[1],
+            )
+            continue
         ordered = False
         found_at, found_entry = _list_find(
             actual_queue,

--- a/tests/truth_tests.bzl
+++ b/tests/truth_tests.bzl
@@ -509,6 +509,35 @@ def _collection_contains_exactly_test(env, _target):
         env = env,
         msg = "check multiplicity; expected with multiple, expected with unique",
     )
+
+    subject = truth.expect(fake_env).that_collection(["one", "four", "three", "two", "five"])
+    order = subject.contains_exactly(["one", "two", "three", "four", "five"])
+    _assert_no_failures(
+        fake_env,
+        env = env,
+        msg = "check same elements with expected in different order",
+    )
+    order.in_order()
+    _assert_failure(
+        fake_env,
+        [
+            "expected values all found, but with incorrect order:",
+            "0: one found at offset 0",
+            "1: two found at offset 3",
+            "2: three found at offset 2",
+            "3: four found at offset 1",
+            "4: five found at offset 4",
+            "actual values:",
+            "0: one",
+            "1: four",
+            "2: three",
+            "3: two",
+            "4: five",
+        ],
+        env = env,
+        msg = "check same elements out of order",
+    )
+
     _end(env, fake_env)
 
 _suite.append(collection_contains_exactly_test)


### PR DESCRIPTION
Fixes the following error when comparing two collections against each other with `contains_exactly` and `in_order`:
```
Error: 'NoneType' value has no field or method 'matched_value'
```