### PR TITLE
cleanup: Upgrade to stardoc 0.5.6 and enable bzlmod for building docs

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -16,9 +16,19 @@ tasks:
     bazel: latest
     test_flags:
       - "--enable_bzlmod"
-      - "--test_tag_filters=-skip-bzlmod"
+      - "--test_tag_filters=-skip-bzlmod,-docs"
     test_targets:
       - "..."
+
+  docs:
+    name: Docs generation
+    platform: ubuntu2004
+    bazel: latest
+    test_flags:
+      - "--enable_bzlmod"
+    test_targets:
+      - "//docgen/..."
+      - "//docs/..."
 
   e2e_bzlmod:
     platform: ${{platform}}

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,7 +14,7 @@ bazel_dep(name = "rules_license", version = "0.0.4")
 # work with bzlmod enabled. This defines the repo so load() works.
 bazel_dep(
     name = "stardoc",
-    version = "0.5.3",
+    version = "0.5.6",
     dev_dependency = True,
     repo_name = "io_bazel_stardoc",
 )

--- a/docgen/BUILD
+++ b/docgen/BUILD
@@ -45,4 +45,5 @@ sphinx_stardocs(
         "//lib/private:str_subject_bzl",
         "//lib/private:target_subject_bzl",
     ],
+    tags = ["docs"],
 )

--- a/docgen/docgen.bzl
+++ b/docgen/docgen.bzl
@@ -29,11 +29,6 @@ def sphinx_stardocs(name, bzl_libraries, **kwargs):
             tags)
     """
 
-    # Stardoc doesn't yet work with bzlmod; we can detect this by
-    # looking for "@@" vs "@" in labels.
-    if "@@" in str(Label("//:X")):
-        kwargs["target_compatible_with"] = ["@platforms//:incompatible"]
-
     docs = []
     for label in bzl_libraries:
         lib_name = Label(label).name.replace("_bzl", "")


### PR DESCRIPTION
The latest version of stardoc supports bzlmod, which makes developing much nicer than using workspace.