### PR TITLE
feat: add DictSubject.get

### DIFF
--- a/lib/private/dict_subject.bzl
+++ b/lib/private/dict_subject.bzl
@@ -39,10 +39,13 @@ def _dict_subject_new(actual, meta, container_name = "dict", key_plural_name = "
 
     # buildifier: disable=uninitialized
     public = struct(
+        # keep sorted start
         contains_exactly = lambda *a, **k: _dict_subject_contains_exactly(self, *a, **k),
         contains_at_least = lambda *a, **k: _dict_subject_contains_at_least(self, *a, **k),
         contains_none_of = lambda *a, **k: _dict_subject_contains_none_of(self, *a, **k),
+        get = lambda *a, **k: _dict_subject_get(self, *a, **k),
         keys = lambda *a, **k: _dict_subject_keys(self, *a, **k),
+        # keep sorted end
     )
     self = struct(
         actual = actual,
@@ -151,6 +154,20 @@ def _dict_subject_contains_none_of(self, none_of):
         ),
         actual = "actual: {{\n{}\n}}".format(format_dict_as_lines(self.actual)),
     )
+
+def _dict_subject_get(self, key, *, factory):
+    """Gets `key` from the actual dict wrapped in a subject.
+
+    Args:
+        self: implicitly added.
+        key: ([`object`]) the key to fetch.
+        factory: ([`callable`]) subject factory function, with the signature
+            of `def factory(value, *, meta)`, and returns the wrapped value.
+
+    Returns:
+        The return value of the `factory` arg.
+    """
+    return factory(self.actual[key], meta = self.meta.derive("get({})".format(key)))
 
 def _dict_subject_keys(self):
     """Returns a `CollectionSubject` for the dict's keys.

--- a/tests/truth_tests.bzl
+++ b/tests/truth_tests.bzl
@@ -920,6 +920,14 @@ def _dict_subject_test(env, _target):
     fake_env = _fake_env(env)
     subject = truth.expect(fake_env).that_dict({"a": 1, "b": 2, "c": 3})
 
+    def factory(value, *, meta):
+        return struct(value = value, meta = meta)
+
+    actual = subject.get("a", factory = factory)
+
+    truth.expect(env).that_int(actual.value).equals(1)
+    truth.expect(env).that_collection(actual.meta._exprs).contains("get(a)")
+
     subject.contains_exactly({"a": 1, "b": 2, "c": 3})
     _assert_no_failures(fake_env, env = env)
 


### PR DESCRIPTION
This makes it easier to perform checks on keys/values within dicts when different asserts may be required depending on the key.

Fixes #51