### PR TITLE
Add support for `tuple` to collection subjects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
     ([#52](https://github.com/bazelbuild/rules_testing/issues/52))
   * StructSubject for asserting arbitrary structs.
     ([#53](https://github.com/bazelbuild/rules_testing/issues/53))
+  * CollectionSubject now supports tuples.
+    ([#69](https://github.com/bazelbuild/rules_testing/pull/69))
   * (docs) Created human-friendly changelog
 
 ## [0.3.0] - 2023-07-06

--- a/docgen/docgen.bzl
+++ b/docgen/docgen.bzl
@@ -14,8 +14,8 @@
 
 """Rules to help generate rules_testing docs."""
 
-load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
 
 def sphinx_stardocs(name, bzl_libraries, **kwargs):
     """Generate Sphinx-friendly markdown docs using Stardoc for bzl libraries.

--- a/lib/private/default_info_subject.bzl
+++ b/lib/private/default_info_subject.bzl
@@ -14,9 +14,9 @@
 
 """# DefaultInfoSubject"""
 
-load(":runfiles_subject.bzl", "RunfilesSubject")
 load(":depset_file_subject.bzl", "DepsetFileSubject")
 load(":file_subject.bzl", "FileSubject")
+load(":runfiles_subject.bzl", "RunfilesSubject")
 
 def _default_info_subject_new(info, *, meta):
     """Creates a `DefaultInfoSubject`

--- a/lib/private/truth_common.bzl
+++ b/lib/private/truth_common.bzl
@@ -126,11 +126,12 @@ def to_list(obj):
     """Attempt to convert the object to a list, else error.
 
     NOTE: This only supports objects that are typically understood as
-    lists, not any iterable. Types like `dict` and `str` are iterable,
-    but will be rejected.
+    lists, not any iterable. Types like `dict` are iterable, but will
+    be rejected.
 
     Args:
-        obj: ([`list`] | [`depset`]) The object to convert to a list.
+        obj: ([`list`] | [`depset`] | [`tuple`]) The object to convert to a
+            list.
 
     Returns:
         [`list`] of the object
@@ -141,5 +142,7 @@ def to_list(obj):
         return obj
     elif types.is_depset(obj):
         return obj.to_list()
+    elif types.is_tuple(obj):
+        return list(obj)
     else:
         fail("Unable to convert to list: {}".format(repr_with_type(obj)))

--- a/lib/test_suite.bzl
+++ b/lib/test_suite.bzl
@@ -3,8 +3,8 @@
 Aggregates multiple Starlark tests in a single test_suite.
 """
 
-load("//lib/private:util.bzl", "get_test_name_from_function")
 load("//lib:unit_test.bzl", "unit_test")
+load("//lib/private:util.bzl", "get_test_name_from_function")
 
 def test_suite(name, *, tests = [], basic_tests = [], test_kwargs = {}):
     """Instantiates given test macros/implementations and gathers their main targets into a `test_suite`.

--- a/lib/truth.bzl
+++ b/lib/truth.bzl
@@ -51,11 +51,11 @@ load("//lib/private:expect.bzl", "Expect")
 load("//lib/private:file_subject.bzl", "FileSubject")
 load("//lib/private:int_subject.bzl", "IntSubject")
 load("//lib/private:label_subject.bzl", "LabelSubject")
+load("//lib/private:matching.bzl", _matching = "matching")
 load("//lib/private:runfiles_subject.bzl", "RunfilesSubject")
 load("//lib/private:str_subject.bzl", "StrSubject")
-load("//lib/private:target_subject.bzl", "TargetSubject")
-load("//lib/private:matching.bzl", _matching = "matching")
 load("//lib/private:struct_subject.bzl", "StructSubject")
+load("//lib/private:target_subject.bzl", "TargetSubject")
 
 # Rather than load many symbols, just load this symbol, and then all the
 # asserts will be available.

--- a/tests/struct_subject/struct_subject_tests.bzl
+++ b/tests/struct_subject/struct_subject_tests.bzl
@@ -14,8 +14,8 @@
 
 """Tests for StructSubject"""
 
-load("//lib:truth.bzl", "subjects")
 load("//lib:test_suite.bzl", "test_suite")
+load("//lib:truth.bzl", "subjects")
 load("//tests:test_util.bzl", "test_util")
 
 _tests = []

--- a/tests/test_util.bzl
+++ b/tests/test_util.bzl
@@ -14,9 +14,10 @@
 
 """Utilities for testing rules_testing code."""
 
+load("//lib:truth.bzl", "matching")
+
 # buildifier: disable=bzl-visibility
 load("//lib/private:expect_meta.bzl", "ExpectMeta")
-load("//lib:truth.bzl", "matching")
 
 def _fake_meta(real_env):
     """Create a fake ExpectMeta object for testing.

--- a/tests/truth_tests.bzl
+++ b/tests/truth_tests.bzl
@@ -538,6 +538,34 @@ def _collection_contains_exactly_test(env, _target):
         msg = "check same elements out of order",
     )
 
+    subject = truth.expect(fake_env).that_collection(("one", "four", "three", "two", "five"))
+    order = subject.contains_exactly(("one", "two", "three", "four", "five"))
+    _assert_no_failures(
+        fake_env,
+        env = env,
+        msg = "check same elements with expected in different order",
+    )
+    order.in_order()
+    _assert_failure(
+        fake_env,
+        [
+            "expected values all found, but with incorrect order:",
+            "0: one found at offset 0",
+            "1: two found at offset 3",
+            "2: three found at offset 2",
+            "3: four found at offset 1",
+            "4: five found at offset 4",
+            "actual values:",
+            "0: one",
+            "1: four",
+            "2: three",
+            "3: two",
+            "4: five",
+        ],
+        env = env,
+        msg = "check same elements out of order",
+    )
+
     _end(env, fake_env)
 
 _suite.append(collection_contains_exactly_test)

--- a/tests/truth_tests.bzl
+++ b/tests/truth_tests.bzl
@@ -15,8 +15,8 @@
 """Tests for truth.bzl."""
 
 load("@bazel_skylib//lib:unittest.bzl", ut_asserts = "asserts")
-load("//lib:truth.bzl", "matching", "subjects", "truth")
 load("//lib:analysis_test.bzl", "analysis_test", "test_suite")
+load("//lib:truth.bzl", "matching", "subjects", "truth")
 
 # Bazel 5 has a bug where every access of testing.ExecutionInfo is a new
 # object that isn't equal to itself. This is fixed in Bazel 6.

--- a/tests/unit_test_tests.bzl
+++ b/tests/unit_test_tests.bzl
@@ -1,7 +1,7 @@
 """Tests for unit_test."""
 
-load("//lib:unit_test.bzl", "unit_test")
 load("//lib:test_suite.bzl", "test_suite")
+load("//lib:unit_test.bzl", "unit_test")
 
 def _test_basic(env):
     _ = env  # @unused


### PR DESCRIPTION
`tuple`s are as list-like or more than `depset`s, but previously resulted in a `fail` when passed to collection subject functions.

Along the way remove an incorrect comment about `str` being iterable, which it is in Python but not in Starlark.