### PR TITLE
chore: Disable Bzlmod explicitly for workspace setup

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -9,6 +9,7 @@ tasks:
     platform: ${{platform}}
     bazel: ${{bazel}}
     test_targets:
+      - "--noenable_bzlmod"
       - "..."
   all_tests_bzlmod:
     name: Bzlmod

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -8,8 +8,9 @@ tasks:
     name: Workspace
     platform: ${{platform}}
     bazel: ${{bazel}}
+    test_flags:
+      - "--noexperimental_enable_bzlmod"
     test_targets:
-      - "--noenable_bzlmod"
       - "..."
   all_tests_bzlmod:
     name: Bzlmod


### PR DESCRIPTION
The upcoming Bazel version defaults to having bzlmod enabled, which means workspace
builds will need to explicitly disable it to continue to be workspace-based.

https://github.com/bazelbuild/bazel/issues/18958