### PR TITLE
Explicitly enable WORKSPACE in WORKSPACE tests

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -2,12 +2,20 @@ buildifier: latest
 validate_config: 1
 matrix:
   platform: ["ubuntu2004", "windows", "macos"]
-  bazel: ["latest", "5.x"]
 tasks:
-  all_tests_workspace:
-    name: Workspace
+  all_tests_workspace_latest:
+    name: Workspace (latest Bazel)
     platform: ${{platform}}
-    bazel: ${{bazel}}
+    bazel: latest
+    test_flags:
+      - "--noenable_bzlmod"
+      - "--enable_workspace"
+    test_targets:
+      - "..."
+  all_tests_workspace_5.0:
+    name: Workspace (Bazel 5.0)
+    platform: ${{platform}}
+    bazel: 5.0
     test_flags:
       - "--noexperimental_enable_bzlmod"
     test_targets:


### PR DESCRIPTION
except for Bazel 5.0, which doesn't have the `--enable_workspace` flag.

Fixes https://github.com/bazelbuild/rules_testing/issues/104