### PR TITLE
chore: Use Bazel 6 and minimum tested Bazel version

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -12,13 +12,13 @@ tasks:
       - "--enable_workspace"
     test_targets:
       - "..."
-  all_tests_workspace_5.x:
-    name: Workspace (Bazel 5.x)
+  all_tests_workspace_minimum_bazel:
+    name: Workspace (minimum Bazel)
     platform: ${{platform}}
     skip_in_bazel_downstream_pipeline: Already tested on latest
-    bazel: "5.x"
+    bazel: "6.x"
     test_flags:
-      - "--noexperimental_enable_bzlmod"
+      - "--noenable_bzlmod"
     test_targets:
       - "..."
   all_tests_bzlmod:


### PR DESCRIPTION
Bazel 5 is out of support, so switch to using Bazel 6