### PR TITLE
chore(deps): stardoc, rules_python, rules_cc, protobuf, rule_java

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,11 +14,11 @@ bazel_dep(name = "rules_license", version = "0.0.4")
 # work with bzlmod enabled. This defines the repo so load() works.
 bazel_dep(
     name = "stardoc",
-    version = "0.6.2",
+    version = "0.7.1",
     dev_dependency = True,
     repo_name = "io_bazel_stardoc",
 )
-bazel_dep(name = "rules_python", version = "0.27.0", dev_dependency = True)
+bazel_dep(name = "rules_python", version = "0.37.2", dev_dependency = True)
 
 python = use_extension(
     "@rules_python//python/extensions:python.bzl",

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -3,12 +3,18 @@ workspace(name = "rules_testing")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
-maybe(
-    http_archive,
+http_archive(
+    name = "rules_python",
+    sha256 = "c6fb25d0ba0246f6d5bd820dd0b2e66b339ccc510242fd4956b9a639b548d113",
+    strip_prefix = "rules_python-0.37.2",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.37.2/rules_python-0.37.2.tar.gz",
+)
+
+http_archive(
     name = "rules_java",
-    sha256 = "6f3ce0e9fba979a844faba2d60467843fbf5191d8ca61fa3d2ea17655b56bb8c",
+    sha256 = "a9690bc00c538246880d5c83c233e4deb83fe885f54c21bb445eb8116a180b83",
     urls = [
-        "https://github.com/bazelbuild/rules_java/releases/download/7.11.1/rules_java-7.11.1.tar.gz",
+        "https://github.com/bazelbuild/rules_java/releases/download/7.12.2/rules_java-7.12.2.tar.gz",
     ],
 )
 
@@ -24,12 +30,32 @@ maybe(
 
 http_archive(
     name = "io_bazel_stardoc",
-    sha256 = "62bd2e60216b7a6fec3ac79341aa201e0956477e7c8f6ccc286f279ad1d96432",
+    sha256 = "fabb280f6c92a3b55eed89a918ca91e39fb733373c81e87a18ae9e33e75023ec",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/stardoc/releases/download/0.6.2/stardoc-0.6.2.tar.gz",
-        "https://github.com/bazelbuild/stardoc/releases/download/0.6.2/stardoc-0.6.2.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/stardoc/releases/download/0.7.1/stardoc-0.7.1.tar.gz",
+        "https://github.com/bazelbuild/stardoc/releases/download/0.7.1/stardoc-0.7.1.tar.gz",
     ],
 )
+
+http_archive(
+    name = "rules_cc",
+    sha256 = "d9bdd3ec66b6871456ec9c965809f43a0901e692d754885e89293807762d3d80",
+    strip_prefix = "rules_cc-0.0.13",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.13/rules_cc-0.0.13.tar.gz"],
+)
+
+http_archive(
+    name = "protobuf",
+    sha256 = "da288bf1daa6c04d03a9051781caa52aceb9163586bff9aa6cfb12f69b9395aa",
+    strip_prefix = "protobuf-27.0",
+    url = "https://github.com/protocolbuffers/protobuf/releases/download/v27.0/protobuf-27.0.tar.gz",
+)
+
+load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
+
+rules_java_dependencies()
+
+rules_java_toolchains()
 
 load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
 
@@ -52,14 +78,9 @@ http_archive(
     ],
 )
 
-http_archive(
-    name = "rules_python",
-    sha256 = "a644da969b6824cc87f8fe7b18101a8a6c57da5db39caa6566ec6109f37d2141",
-    strip_prefix = "rules_python-0.20.0",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/0.20.0/rules_python-0.20.0.tar.gz",
-)
+load("@rules_python//python:repositories.bzl", "py_repositories", "python_register_toolchains")
 
-load("@rules_python//python:repositories.bzl", "python_register_toolchains")
+py_repositories()
 
 python_register_toolchains(
     name = "python3_11",


### PR DESCRIPTION
Updates various dev dependencies to better support upcoming Bazel versions.

* stardoc 0.6.2 -> 0.7.1
* rules_python 0.20.0 -> 0.37.2
* rules_cc 0.0.13 (workspace only)
* protobuf 27.0 (necessary for rules_cc, workspace only)
* rules_java 7.11.1 -> 7.12.2

Work towards #108, #109, #114