### PR TITLE
chore: upgrade CI from Bazel 5 to 6

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -19,7 +19,7 @@ tasks:
     bazel: "6.x"
     test_flags:
       - "--noenable_bzlmod"
-      - "--enable_workspace"
+      - "--test_tag_filters=-docs"
     test_targets:
       - "..."
   all_tests_bzlmod:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -18,7 +18,8 @@ tasks:
     skip_in_bazel_downstream_pipeline: Already tested on latest
     bazel: "6.x"
     test_flags:
-      - "--noexperimental_enable_bzlmod"
+      - "--noenable_bzlmod"
+      - "--enable_workspace"
     test_targets:
       - "..."
   all_tests_bzlmod:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -20,9 +20,7 @@ tasks:
     test_flags:
       - "--noenable_bzlmod"
     test_targets:
-      - "..."
-      - "-//docgen/..."
-      - "-//docs/..."      
+      - "//tests/..." 
   all_tests_bzlmod:
     name: Bzlmod
     platform: ${{platform}}

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -20,7 +20,7 @@ tasks:
     test_flags:
       - "--noenable_bzlmod"
     test_targets:
-      - "//tests/..." 
+      - "//tests/..."
   all_tests_bzlmod:
     name: Bzlmod
     platform: ${{platform}}

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -19,9 +19,10 @@ tasks:
     bazel: "6.x"
     test_flags:
       - "--noenable_bzlmod"
-      - "--test_tag_filters=-docs"
     test_targets:
       - "..."
+      - "-//docgen/..."
+      - "-//docs/..."      
   all_tests_bzlmod:
     name: Bzlmod
     platform: ${{platform}}

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -12,11 +12,11 @@ tasks:
       - "--enable_workspace"
     test_targets:
       - "..."
-  all_tests_workspace_5.x:
-    name: Workspace (Bazel 5.x)
+  all_tests_workspace_6.x:
+    name: Workspace (Bazel 6.x)
     platform: ${{platform}}
     skip_in_bazel_downstream_pipeline: Already tested on latest
-    bazel: "5.x"
+    bazel: "6.x"
     test_flags:
       - "--noexperimental_enable_bzlmod"
     test_targets:


### PR DESCRIPTION
Builds started failing with Bazel 5, because rules_java dependencies were upgraded.