### PR TITLE
loadingtests: add default timeout

### DIFF
--- a/lib/unittest.bzl
+++ b/lib/unittest.bzl
@@ -647,7 +647,7 @@ def _loading_make(name):
     )
     return struct(name = name)
 
-def _loading_assert_equals(env, test_case, expected, actual):
+def _loading_assert_equals(env, test_case, expected, actual, timeout = "short"):
     """Creates a test case for asserting state at LOADING phase.
 
     Args:
@@ -655,6 +655,7 @@ def _loading_assert_equals(env, test_case, expected, actual):
       test_case: Name of the test case
       expected:  Expected value to test
       actual:    Actual value received.
+      timeout:   Test timeout passed into the generated rule.
 
     Returns:
       None, creates test case
@@ -668,6 +669,7 @@ def _loading_assert_equals(env, test_case, expected, actual):
         name = "%s_%s" % (env.name, test_case),
         failure_message = msg,
         tags = [env.name + "_test_case"],
+        timeout = timeout,
     )
 
 asserts = struct(


### PR DESCRIPTION
loadingtests didn't provide a way to set a timeout, which means they trip --test_verbose_timeout_warnings; this provides a basic way to do so, and sets a default timeout of short since normal loadingtests would have a hard time successfully being any larger.

(This is the same as https://github.com/bazelbuild/bazel-skylib/pull/572, but skylib seems to not be taking contributions anymore)