### PR TITLE
Migrate macos jobs to macos_arm64

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,7 +1,7 @@
 buildifier: latest
 validate_config: 1
 matrix:
-  platform: ["ubuntu2004", "windows", "macos"]
+  platform: ["ubuntu2004", "windows", "macos_arm64"]
 tasks:
   all_tests_workspace_latest:
     name: Workspace (latest Bazel)


### PR DESCRIPTION
The Intel `macos` deployment in BazelCI does not have the latest Android build tools installed. By default, BazelCI adds `ANDROID*` environment variables to builds, which registers an Android toolchain for any transitively-loaded Android deps, which causes a repo rule-level error.

To prevent this, this PR migrates `macos` jobs to `macos_arm64`.